### PR TITLE
Add check for global pattern match

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,21 +42,29 @@ async function getRequiredCodeowners(changedFiles, repo, pr, octokit) {
 
         const [pattern, ...owners] = line.trim().split(/\s+/);
 
-        for (const changedFile of changedFiles) {
-            if (minimatch(changedFile, pattern)) {
-                for (let owner of owners) {
-                    owner = owner.replace(/[<>\(\)\[\]\{\},;+*?=]/g, "");
-                    owner = owner.replace("@", "").split("/").pop();
-                    owner = owner.toLowerCase();
-                    if (!codeowners.hasOwnProperty(owner)) {
-                        codeowners[owner] = false;
-                    }
+        if (pattern === '*') {
+            updateCodeowners(owners);
+        } else {
+            for (const changedFile of changedFiles) {
+                if (minimatch(changedFile, pattern)) {
+                    updateCodeowners(owners);
                 }
             }
         }
     }
 
     return codeowners;
+
+    function updateCodeowners(owners) {
+        for (let owner of owners) {
+            owner = owner.replace(/[<>\(\)\[\]\{\},;+*?=]/g, "");
+            owner = owner.replace("@", "").split("/").pop();
+            owner = owner.toLowerCase();
+            if (!codeowners.hasOwnProperty(owner)) {
+                codeowners[owner] = false;
+            }
+        }
+    }
 }
 
 async function getUserTeams(username, orgName, orgTeams, octokit) {


### PR DESCRIPTION
minimatch doesn't match the default global owner pattern as specified here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

This adds a simple check for the global pattern (`*`) as then checking each file won't matter as it falls under the global owners of the repository.